### PR TITLE
Initial configuration minor improvements

### DIFF
--- a/CPC.js
+++ b/CPC.js
@@ -89,6 +89,7 @@
                 }
                 if (message.data.type === 'init' && message.data.payload.value.length === 0) {
                     this._getUserData();
+                    this._initOngoingInteractions();
                 } else if (message.data.type === 'response' && _oPendingActions[message.data.id]) {
                     Log('DBG', 'message', 'Got response for action [' + message.data.id + ']: ' + JSON.stringify(message.data));
                     _oPendingActions[message.data.id].response = message.data;
@@ -1213,6 +1214,30 @@
                             value: this.currentUser
                         }
                     });
+                })
+        };
+
+        /**
+         * Initial ongoing interactions synchronization. Meant to be used during CPC load
+         * @private
+         */
+        this._initOngoingInteractions = () => {
+            this.getDetails('interactions')
+                .then(res => {
+                    if (res) {
+                        [...res.payload.value].forEach(interaction => {
+                            _oInteractions.set(interaction.id, interaction)
+                        })
+                    }
+                    const event = {
+                        id: 'cpc-init-ongoing-interactions',
+                        type: 'state',
+                        payload: {
+                            attribute: 'ongoingInteractions',
+                            value: _oInteractions
+                        }
+                    }
+                    this.hostAppEventHandler(event)
                 })
         };
     }();

--- a/CPC.js
+++ b/CPC.js
@@ -88,20 +88,7 @@
                     Log('DBG', 'startMessageListener.message', 'First message receieved from CP, setting CPC.isInitialised to true');
                 }
                 if (message.data.type === 'init' && message.data.payload.value.length === 0) {
-                    const getUserData = async () => {
-                        const userDetailsResponse = await this.getDetails('user');
-                        this.currentUser = userDetailsResponse.payload.value;
-                        this.hostAppEventHandler({
-                            // Fabricate an event to notify customer event handler of when CPC has successfully initialized window messaging with Communication Panel.
-                            id: 'cpc-init',
-                            type: 'status',
-                            payload: {
-                                attribute: 'init',
-                                value: this.currentUser
-                            }
-                        });
-                    };
-                    getUserData();
+                    this._getUserData();
                 } else if (message.data.type === 'response' && _oPendingActions[message.data.id]) {
                     Log('DBG', 'message', 'Got response for action [' + message.data.id + ']: ' + JSON.stringify(message.data));
                     _oPendingActions[message.data.id].response = message.data;
@@ -1207,6 +1194,26 @@
             }
             this.hostAppEventHandler(oReturn);
             return oReturn;
+        };
+
+        /**
+         * Initial user's data synchronization. Meant to be used during CPC load
+         * @private
+         */
+        this._getUserData = () => {
+            this.getDetails('user')
+                .then(res => {
+                    this.currentUser = res.payload.value;
+                    this.hostAppEventHandler({
+                        // Fabricate an event to notify customer event handler of when CPC has successfully initialized window messaging with Communication Panel.
+                        id: 'cpc-init',
+                        type: 'status',
+                        payload: {
+                            attribute: 'init',
+                            value: this.currentUser
+                        }
+                    });
+                })
         };
     }();
 


### PR DESCRIPTION
Fix issue with abandoned interactions. Increase readability.

It is possible some interactions to stay ongoing when a session is over, mainly in case of emails.
To fix the case when a new session is unaware of those, the `_this.initOngoingInteractions` was introduced.

During the fix, the function of user initialization was extracted just for better readability.